### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 MSP430G2253-to-LCD-via-ILI9341_v0.8
 ===================================
 
-MSP430G2553 (Launchpad) C project used to run LCD based on the ILI9341 SOC. The new version is commited. Timer clock is now using auxilliary quartz oscilator at base frequency of 32,768 Hz.
+MSP430G2553 (Launchpad) C project used to run LCD based on the ILI9341 SOC. The new version is commited. Timer clock is now using auxiliary quartz oscilator at base frequency of 32,768 Hz.


### PR DESCRIPTION
Sruk, I've corrected a typographical error in the documentation of the [MSP430G2253-to-LCD-via-ILI9341_v0.8](https://github.com/Sruk/MSP430G2253-to-LCD-via-ILI9341_v0.8) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
